### PR TITLE
Use `mutable.Map` instead of `mutable.HashMap`

### DIFF
--- a/internal/compiler-bridge/src/main/scala_2.11-13/xsbt/PicklerGen.scala
+++ b/internal/compiler-bridge/src/main/scala_2.11-13/xsbt/PicklerGen.scala
@@ -38,7 +38,7 @@ final class PicklerGen(val global: CallbackGlobal) extends Compat with GlobalHel
       new URI("pickle", global.hashCode().toString, global.currentRunId.toString)
 
     case class PickleMapping(name: String, symbol: Symbol, bytes: Array[Byte])
-    def toMappings(pickles: mutable.HashMap[global.Symbol, PickleBuffer]): List[PickleMapping] = {
+    def toMappings(pickles: mutable.Map[global.Symbol, PickleBuffer]): List[PickleMapping] = {
       pickles.toList.flatMap {
         case (symbol, pickle) =>
           val javaName = symbol.javaBinaryNameString

--- a/internal/zinc-ivy-integration/src/test/scala/sbt/internal/inc/ZincComponentCompilerSpec.scala
+++ b/internal/zinc-ivy-integration/src/test/scala/sbt/internal/inc/ZincComponentCompilerSpec.scala
@@ -11,6 +11,7 @@ class ZincComponentCompilerSpec extends BridgeProviderSpecification {
   val scala2121 = "2.12.1"
   val scala2122 = "2.12.2"
   val scala2123 = "2.12.3"
+  val scala2127 = "2.12.7"
   val scala2130M2 = "2.13.0-M2"
 
   val logger = ConsoleLogger()
@@ -28,6 +29,7 @@ class ZincComponentCompilerSpec extends BridgeProviderSpecification {
     IO.withTemporaryDirectory(t => getCompilerBridge(t, logger, scala2121) should exist)
     IO.withTemporaryDirectory(t => getCompilerBridge(t, logger, scala2122) should exist)
     IO.withTemporaryDirectory(t => getCompilerBridge(t, logger, scala2123) should exist)
+    IO.withTemporaryDirectory(t => getCompilerBridge(t, logger, scala2127) should exist)
   }
 
   it should "compile the bridge for Scala 2.13.0-M2" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.contraband.ContrabandPlugin.autoImport._
 object Dependencies {
   val scala210 = "2.10.7"
   val scala211 = "2.11.12"
-  val scala212 = "2.12.6"
+  val scala212 = "2.12.7"
   val scala213 = "2.13.0-M2"
 
   private val ioVersion = "1.2.0"

--- a/zinc/src/sbt-test/source-dependencies/trait-trait-212/build.json
+++ b/zinc/src/sbt-test/source-dependencies/trait-trait-212/build.json
@@ -2,7 +2,7 @@
   "projects": [
     {
       "name": "mirtest",
-      "scalaVersion": "2.12.6"
+      "scalaVersion": "2.12.7"
     }
   ]
 }


### PR DESCRIPTION
The signature changed in Scala 2.12.7, so we pick the lub of `AnyRefMap` and
`HashMap` which is `mutable.Map`.