### PR TITLE
Introduce pickles/tasty compatible API for pipelining

### DIFF
--- a/internal/compiler-bridge-test/src/test/scala/xsbt/OutlineSpecification.scala
+++ b/internal/compiler-bridge-test/src/test/scala/xsbt/OutlineSpecification.scala
@@ -89,7 +89,7 @@ class OutlineSpecification extends UnitSpec {
     // The compilation is sequential (whereas it could be in parallel), but there
     // is no resource sharing (e.g. class dirs) so it emulates a real-world scenario.
     val compiler.CompilationResult(_, testCallback, _) =
-      compiler.compileProject(projectA, Nil, Nil)
+      compiler.compileProject(projectA, Nil, Array.empty)
     val dependencies = TestCallback.fromCallback(testCallback)
     assert(dependencies.memberRef("A") === Set.empty)
     assert(dependencies.memberRef("T") === Set("SuperAccessorApply", "SuperAccessorSelect"))

--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -14,13 +14,11 @@ import scala.tools.nsc._
 import io.AbstractFile
 import java.io.File
 
-import com.github.difflib.{ DiffUtils, UnifiedDiffUtils }
-
 /** Defines the interface of the incremental compiler hiding implementation details. */
 sealed abstract class CallbackGlobal(
     settings: Settings,
     reporter: reporters.Reporter,
-    output: Output
+    val output: Output
 ) extends Global(settings, reporter)
     with ZincPicklePath {
 
@@ -261,6 +259,7 @@ sealed class ZincCompiler(
 
   final def set(callback: AnalysisCallback, dreporter: DelegatingReporter): Unit = {
     this.callback0 = callback
+    this.clearStore()
     reporter = dreporter
   }
 

--- a/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/Dependency.scala
@@ -125,6 +125,11 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile with 
           case pf: PlainFile =>
             // The dependency comes from a class file
             binaryDependency(pf.file, binaryClassName)
+
+          case PicklerGen.PickleFile(f) =>
+            // The dependency comes from an in-memory ir (build pipelining is enabled)
+            binaryDependency(f, binaryClassName)
+
           case _ =>
             reporter.error(
               NoPosition,

--- a/internal/compiler-bridge/src/main/scala_2.10/scala/tools/nsc/ZincPicklePath.scala
+++ b/internal/compiler-bridge/src/main/scala_2.10/scala/tools/nsc/ZincPicklePath.scala
@@ -1,9 +1,19 @@
 package scala.tools.nsc
 
 import java.net.URI
+import xsbti.compile.{IRStore, EmptyIRStore}
 
 trait ZincPicklePath {
   self: Global =>
 
-  def extendClassPathWithPicklePath(picklepath: List[URI]): Unit = ()
+  private[this] var store0: IRStore = EmptyIRStore.getStore()
+
+  /** Returns the active IR store, set by [[setUpIRStore()]] and cleared by [[clearStore()]]. */
+  def store: IRStore = store0
+
+  def clearStore(): Unit = {
+    this.store0 = EmptyIRStore.getStore()
+  }
+
+  def setUpIRStore(store: IRStore): Unit = ()
 }

--- a/internal/compiler-bridge/src/main/scala_2.10/xsbt/PicklerGen.scala
+++ b/internal/compiler-bridge/src/main/scala_2.10/xsbt/PicklerGen.scala
@@ -1,5 +1,6 @@
 package xsbt
 
+import scala.reflect.io.AbstractFile
 import scala.tools.nsc.Phase
 
 final class PicklerGen(val global: CallbackGlobal) extends Compat with GlobalHelpers {
@@ -17,4 +18,10 @@ final class PicklerGen(val global: CallbackGlobal) extends Compat with GlobalHel
 
 object PicklerGen {
   def name = "picklergen"
+  final val rootStartId = "☣☖"
+
+  object PickleFile {
+    import java.io.File
+    def unapply(arg: AbstractFile): Option[File] = None
+  }
 }

--- a/internal/compiler-bridge/src/main/scala_2.11/xsbt/ZincSymbolLoaders.scala
+++ b/internal/compiler-bridge/src/main/scala_2.11/xsbt/ZincSymbolLoaders.scala
@@ -19,7 +19,7 @@ abstract class ZincSymbolLoaders extends GlobalSymbolLoaders with ZincPickleComp
         enterToplevelsFromSource(owner, classRep.name, src)
       case (Some(bin), _) =>
         // If the abstract file comes from our pickle index, use our own loader
-        if (bin.path.startsWith(PicklerGen.root)) {
+        if (bin.path.startsWith(PicklerGen.rootStartId)) {
           enterClassAndModule(owner, classRep.name, new ZincPickleLoader(bin))
         } else {
           enterClassAndModule(owner, classRep.name, new ClassfileLoader(bin))

--- a/internal/compiler-bridge/src/main/scala_2.12-13-only/xsbt/ZincSymbolLoaders.scala
+++ b/internal/compiler-bridge/src/main/scala_2.12-13-only/xsbt/ZincSymbolLoaders.scala
@@ -18,7 +18,7 @@ abstract class ZincSymbolLoaders extends GlobalSymbolLoaders with ZincPickleComp
         enterToplevelsFromSource(owner, classRep.name, src)
       case (Some(bin), _) =>
         // If the abstract file comes from our pickle index, use our own loader
-        if (bin.path.startsWith(PicklerGen.root)) {
+        if (bin.path.startsWith(PicklerGen.rootStartId)) {
           enterClassAndModule(owner, classRep.name, new ZincPickleLoader(bin, _, _))
         } else {
           enterClassAndModule(owner, classRep.name, new ClassfileLoader(bin, _, _))

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/CompileOptions.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/CompileOptions.java
@@ -25,11 +25,11 @@ public final class CompileOptions implements java.io.Serializable {
     public static CompileOptions of(java.io.File[] _classpath, java.io.File[] _sources, java.io.File _classesDirectory, String[] _scalacOptions, String[] _javacOptions, xsbti.compile.ClasspathOptions _classpathOptions, int _maxErrors, java.util.function.Function<xsbti.Position, xsbti.Position> _sourcePositionMapper, xsbti.compile.CompileOrder _order) {
         return new CompileOptions(_classpath, _sources, _classesDirectory, _scalacOptions, _javacOptions, _classpathOptions, _maxErrors, _sourcePositionMapper, _order);
     }
-    public static CompileOptions create(java.io.File[] _classpath, java.io.File[] _sources, java.io.File _classesDirectory, String[] _scalacOptions, String[] _javacOptions, xsbti.compile.ClasspathOptions _classpathOptions, int _maxErrors, java.util.function.Function<xsbti.Position, xsbti.Position> _sourcePositionMapper, xsbti.compile.CompileOrder _order, java.net.URI[] _picklepath) {
-        return new CompileOptions(_classpath, _sources, _classesDirectory, _scalacOptions, _javacOptions, _classpathOptions, _maxErrors, _sourcePositionMapper, _order, _picklepath);
+    public static CompileOptions create(java.io.File[] _classpath, java.io.File[] _sources, java.io.File _classesDirectory, String[] _scalacOptions, String[] _javacOptions, xsbti.compile.ClasspathOptions _classpathOptions, int _maxErrors, java.util.function.Function<xsbti.Position, xsbti.Position> _sourcePositionMapper, xsbti.compile.CompileOrder _order, xsbti.compile.IRStore _store) {
+        return new CompileOptions(_classpath, _sources, _classesDirectory, _scalacOptions, _javacOptions, _classpathOptions, _maxErrors, _sourcePositionMapper, _order, _store);
     }
-    public static CompileOptions of(java.io.File[] _classpath, java.io.File[] _sources, java.io.File _classesDirectory, String[] _scalacOptions, String[] _javacOptions, xsbti.compile.ClasspathOptions _classpathOptions, int _maxErrors, java.util.function.Function<xsbti.Position, xsbti.Position> _sourcePositionMapper, xsbti.compile.CompileOrder _order, java.net.URI[] _picklepath) {
-        return new CompileOptions(_classpath, _sources, _classesDirectory, _scalacOptions, _javacOptions, _classpathOptions, _maxErrors, _sourcePositionMapper, _order, _picklepath);
+    public static CompileOptions of(java.io.File[] _classpath, java.io.File[] _sources, java.io.File _classesDirectory, String[] _scalacOptions, String[] _javacOptions, xsbti.compile.ClasspathOptions _classpathOptions, int _maxErrors, java.util.function.Function<xsbti.Position, xsbti.Position> _sourcePositionMapper, xsbti.compile.CompileOrder _order, xsbti.compile.IRStore _store) {
+        return new CompileOptions(_classpath, _sources, _classesDirectory, _scalacOptions, _javacOptions, _classpathOptions, _maxErrors, _sourcePositionMapper, _order, _store);
     }
     /**
      * The classpath to use for compilation.
@@ -52,14 +52,8 @@ public final class CompileOptions implements java.io.Serializable {
     private java.util.function.Function<xsbti.Position, xsbti.Position> sourcePositionMapper;
     /** Controls the order in which Java and Scala sources are compiled. */
     private xsbti.compile.CompileOrder order;
-    /**
-     * Defines the picklepath to use for compilation.
-     * A pickle path is the collection of URI handles that identify in-memory
-     * Scala pickles. These pickles allow Zinc to pipeline compilation of
-     * multi-module builds, allowing downstream modules to start compilation
-     * after the phase pickler has been executed in all the dependent modules.
-     */
-    private java.net.URI[] picklepath;
+    /** Defines the IR store to use for compilation. Check the scaladoc of IR store. */
+    private xsbti.compile.IRStore store;
     protected CompileOptions() {
         super();
         classpath = new java.io.File[0];
@@ -71,7 +65,7 @@ public final class CompileOptions implements java.io.Serializable {
         maxErrors = 100;
         sourcePositionMapper = new java.util.function.Function<xsbti.Position, xsbti.Position>() { public xsbti.Position apply(xsbti.Position a) { return a; } };
         order = xsbti.compile.CompileOrder.Mixed;
-        picklepath = new java.net.URI[0];
+        store = xsbti.compile.EmptyIRStore.getStore();
     }
     protected CompileOptions(java.io.File[] _classpath, java.io.File[] _sources, java.io.File _classesDirectory, String[] _scalacOptions, String[] _javacOptions, int _maxErrors, java.util.function.Function<xsbti.Position, xsbti.Position> _sourcePositionMapper, xsbti.compile.CompileOrder _order) {
         super();
@@ -84,7 +78,7 @@ public final class CompileOptions implements java.io.Serializable {
         maxErrors = _maxErrors;
         sourcePositionMapper = _sourcePositionMapper;
         order = _order;
-        picklepath = new java.net.URI[0];
+        store = xsbti.compile.EmptyIRStore.getStore();
     }
     protected CompileOptions(java.io.File[] _classpath, java.io.File[] _sources, java.io.File _classesDirectory, String[] _scalacOptions, String[] _javacOptions, xsbti.compile.ClasspathOptions _classpathOptions, int _maxErrors, java.util.function.Function<xsbti.Position, xsbti.Position> _sourcePositionMapper, xsbti.compile.CompileOrder _order) {
         super();
@@ -97,9 +91,9 @@ public final class CompileOptions implements java.io.Serializable {
         maxErrors = _maxErrors;
         sourcePositionMapper = _sourcePositionMapper;
         order = _order;
-        picklepath = new java.net.URI[0];
+        store = xsbti.compile.EmptyIRStore.getStore();
     }
-    protected CompileOptions(java.io.File[] _classpath, java.io.File[] _sources, java.io.File _classesDirectory, String[] _scalacOptions, String[] _javacOptions, xsbti.compile.ClasspathOptions _classpathOptions, int _maxErrors, java.util.function.Function<xsbti.Position, xsbti.Position> _sourcePositionMapper, xsbti.compile.CompileOrder _order, java.net.URI[] _picklepath) {
+    protected CompileOptions(java.io.File[] _classpath, java.io.File[] _sources, java.io.File _classesDirectory, String[] _scalacOptions, String[] _javacOptions, xsbti.compile.ClasspathOptions _classpathOptions, int _maxErrors, java.util.function.Function<xsbti.Position, xsbti.Position> _sourcePositionMapper, xsbti.compile.CompileOrder _order, xsbti.compile.IRStore _store) {
         super();
         classpath = _classpath;
         sources = _sources;
@@ -110,7 +104,7 @@ public final class CompileOptions implements java.io.Serializable {
         maxErrors = _maxErrors;
         sourcePositionMapper = _sourcePositionMapper;
         order = _order;
-        picklepath = _picklepath;
+        store = _store;
     }
     public java.io.File[] classpath() {
         return this.classpath;
@@ -139,38 +133,38 @@ public final class CompileOptions implements java.io.Serializable {
     public xsbti.compile.CompileOrder order() {
         return this.order;
     }
-    public java.net.URI[] picklepath() {
-        return this.picklepath;
+    public xsbti.compile.IRStore store() {
+        return this.store;
     }
     public CompileOptions withClasspath(java.io.File[] classpath) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, picklepath);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, store);
     }
     public CompileOptions withSources(java.io.File[] sources) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, picklepath);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, store);
     }
     public CompileOptions withClassesDirectory(java.io.File classesDirectory) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, picklepath);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, store);
     }
     public CompileOptions withScalacOptions(String[] scalacOptions) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, picklepath);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, store);
     }
     public CompileOptions withJavacOptions(String[] javacOptions) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, picklepath);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, store);
     }
     public CompileOptions withClasspathOptions(xsbti.compile.ClasspathOptions classpathOptions) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, picklepath);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, store);
     }
     public CompileOptions withMaxErrors(int maxErrors) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, picklepath);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, store);
     }
     public CompileOptions withSourcePositionMapper(java.util.function.Function<xsbti.Position, xsbti.Position> sourcePositionMapper) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, picklepath);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, store);
     }
     public CompileOptions withOrder(xsbti.compile.CompileOrder order) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, picklepath);
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, store);
     }
-    public CompileOptions withPicklepath(java.net.URI[] picklepath) {
-        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, picklepath);
+    public CompileOptions withStore(xsbti.compile.IRStore store) {
+        return new CompileOptions(classpath, sources, classesDirectory, scalacOptions, javacOptions, classpathOptions, maxErrors, sourcePositionMapper, order, store);
     }
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -179,13 +173,13 @@ public final class CompileOptions implements java.io.Serializable {
             return false;
         } else {
             CompileOptions o = (CompileOptions)obj;
-            return java.util.Arrays.deepEquals(this.classpath(), o.classpath()) && java.util.Arrays.deepEquals(this.sources(), o.sources()) && this.classesDirectory().equals(o.classesDirectory()) && java.util.Arrays.deepEquals(this.scalacOptions(), o.scalacOptions()) && java.util.Arrays.deepEquals(this.javacOptions(), o.javacOptions()) && this.classpathOptions().equals(o.classpathOptions()) && (this.maxErrors() == o.maxErrors()) && this.sourcePositionMapper().equals(o.sourcePositionMapper()) && this.order().equals(o.order()) && java.util.Arrays.deepEquals(this.picklepath(), o.picklepath());
+            return java.util.Arrays.deepEquals(this.classpath(), o.classpath()) && java.util.Arrays.deepEquals(this.sources(), o.sources()) && this.classesDirectory().equals(o.classesDirectory()) && java.util.Arrays.deepEquals(this.scalacOptions(), o.scalacOptions()) && java.util.Arrays.deepEquals(this.javacOptions(), o.javacOptions()) && this.classpathOptions().equals(o.classpathOptions()) && (this.maxErrors() == o.maxErrors()) && this.sourcePositionMapper().equals(o.sourcePositionMapper()) && this.order().equals(o.order()) && this.store().equals(o.store());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.CompileOptions".hashCode()) + java.util.Arrays.deepHashCode(classpath())) + java.util.Arrays.deepHashCode(sources())) + classesDirectory().hashCode()) + java.util.Arrays.deepHashCode(scalacOptions())) + java.util.Arrays.deepHashCode(javacOptions())) + classpathOptions().hashCode()) + (new Integer(maxErrors())).hashCode()) + sourcePositionMapper().hashCode()) + order().hashCode()) + java.util.Arrays.deepHashCode(picklepath()));
+        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.CompileOptions".hashCode()) + java.util.Arrays.deepHashCode(classpath())) + java.util.Arrays.deepHashCode(sources())) + classesDirectory().hashCode()) + java.util.Arrays.deepHashCode(scalacOptions())) + java.util.Arrays.deepHashCode(javacOptions())) + classpathOptions().hashCode()) + (new Integer(maxErrors())).hashCode()) + sourcePositionMapper().hashCode()) + order().hashCode()) + store().hashCode());
     }
     public String toString() {
-        return "CompileOptions("  + "classpath: " + classpath() + ", " + "sources: " + sources() + ", " + "classesDirectory: " + classesDirectory() + ", " + "scalacOptions: " + scalacOptions() + ", " + "javacOptions: " + javacOptions() + ", " + "classpathOptions: " + classpathOptions() + ", " + "maxErrors: " + maxErrors() + ", " + "sourcePositionMapper: " + sourcePositionMapper() + ", " + "order: " + order() + ", " + "picklepath: " + picklepath() + ")";
+        return "CompileOptions("  + "classpath: " + classpath() + ", " + "sources: " + sources() + ", " + "classesDirectory: " + classesDirectory() + ", " + "scalacOptions: " + scalacOptions() + ", " + "javacOptions: " + javacOptions() + ", " + "classpathOptions: " + classpathOptions() + ", " + "maxErrors: " + maxErrors() + ", " + "sourcePositionMapper: " + sourcePositionMapper() + ", " + "order: " + order() + ", " + "store: " + store() + ")";
     }
 }

--- a/internal/compiler-interface/src/main/contraband-java/xsbti/compile/Setup.java
+++ b/internal/compiler-interface/src/main/contraband-java/xsbti/compile/Setup.java
@@ -6,9 +6,9 @@
 package xsbti.compile;
 /** Configures incremental recompilation. */
 public final class Setup implements java.io.Serializable {
-    public static java.util.concurrent.CompletableFuture<java.util.Optional<java.net.URI>> defaultPicklePromise() {
-        java.util.concurrent.CompletableFuture<java.util.Optional<java.net.URI>> p = new java.util.concurrent.CompletableFuture<java.util.Optional<java.net.URI>>();
-        p.complete(java.util.Optional.empty());
+    public static java.util.concurrent.CompletableFuture<xsbti.compile.IR[]> defaultIRPromise() {
+        java.util.concurrent.CompletableFuture<xsbti.compile.IR[]> p = new java.util.concurrent.CompletableFuture<xsbti.compile.IR[]>();
+        p.complete(new xsbti.compile.IR[0]);
         return p;
     }
     public static Setup create(xsbti.compile.PerClasspathEntryLookup _perClasspathEntryLookup, boolean _skip, java.io.File _cacheFile, xsbti.compile.GlobalsCache _cache, xsbti.compile.IncOptions _incrementalCompilerOptions, xsbti.Reporter _reporter, java.util.Optional<xsbti.compile.CompileProgress> _progress, xsbti.T2<String, String>[] _extra) {
@@ -17,11 +17,11 @@ public final class Setup implements java.io.Serializable {
     public static Setup of(xsbti.compile.PerClasspathEntryLookup _perClasspathEntryLookup, boolean _skip, java.io.File _cacheFile, xsbti.compile.GlobalsCache _cache, xsbti.compile.IncOptions _incrementalCompilerOptions, xsbti.Reporter _reporter, java.util.Optional<xsbti.compile.CompileProgress> _progress, xsbti.T2<String, String>[] _extra) {
         return new Setup(_perClasspathEntryLookup, _skip, _cacheFile, _cache, _incrementalCompilerOptions, _reporter, _progress, _extra);
     }
-    public static Setup create(xsbti.compile.PerClasspathEntryLookup _perClasspathEntryLookup, boolean _skip, java.io.File _cacheFile, xsbti.compile.GlobalsCache _cache, xsbti.compile.IncOptions _incrementalCompilerOptions, xsbti.Reporter _reporter, java.util.Optional<xsbti.compile.CompileProgress> _progress, xsbti.T2<String, String>[] _extra, java.util.concurrent.CompletableFuture<java.util.Optional<java.net.URI>> _picklePromise) {
-        return new Setup(_perClasspathEntryLookup, _skip, _cacheFile, _cache, _incrementalCompilerOptions, _reporter, _progress, _extra, _picklePromise);
+    public static Setup create(xsbti.compile.PerClasspathEntryLookup _perClasspathEntryLookup, boolean _skip, java.io.File _cacheFile, xsbti.compile.GlobalsCache _cache, xsbti.compile.IncOptions _incrementalCompilerOptions, xsbti.Reporter _reporter, java.util.Optional<xsbti.compile.CompileProgress> _progress, xsbti.T2<String, String>[] _extra, java.util.concurrent.CompletableFuture<xsbti.compile.IR[]> _irPromise) {
+        return new Setup(_perClasspathEntryLookup, _skip, _cacheFile, _cache, _incrementalCompilerOptions, _reporter, _progress, _extra, _irPromise);
     }
-    public static Setup of(xsbti.compile.PerClasspathEntryLookup _perClasspathEntryLookup, boolean _skip, java.io.File _cacheFile, xsbti.compile.GlobalsCache _cache, xsbti.compile.IncOptions _incrementalCompilerOptions, xsbti.Reporter _reporter, java.util.Optional<xsbti.compile.CompileProgress> _progress, xsbti.T2<String, String>[] _extra, java.util.concurrent.CompletableFuture<java.util.Optional<java.net.URI>> _picklePromise) {
-        return new Setup(_perClasspathEntryLookup, _skip, _cacheFile, _cache, _incrementalCompilerOptions, _reporter, _progress, _extra, _picklePromise);
+    public static Setup of(xsbti.compile.PerClasspathEntryLookup _perClasspathEntryLookup, boolean _skip, java.io.File _cacheFile, xsbti.compile.GlobalsCache _cache, xsbti.compile.IncOptions _incrementalCompilerOptions, xsbti.Reporter _reporter, java.util.Optional<xsbti.compile.CompileProgress> _progress, xsbti.T2<String, String>[] _extra, java.util.concurrent.CompletableFuture<xsbti.compile.IR[]> _irPromise) {
+        return new Setup(_perClasspathEntryLookup, _skip, _cacheFile, _cache, _incrementalCompilerOptions, _reporter, _progress, _extra, _irPromise);
     }
     /** Provides a lookup of data structures and operations associated with a single classpath entry. */
     private xsbti.compile.PerClasspathEntryLookup perClasspathEntryLookup;
@@ -45,7 +45,7 @@ public final class Setup implements java.io.Serializable {
      * the compiler is past the pickler gen phase, so that compilation
      * clients can potentially start compilation of downstream projects.
      */
-    private java.util.concurrent.CompletableFuture<java.util.Optional<java.net.URI>> picklePromise;
+    private java.util.concurrent.CompletableFuture<xsbti.compile.IR[]> irPromise;
     protected Setup(xsbti.compile.PerClasspathEntryLookup _perClasspathEntryLookup, boolean _skip, java.io.File _cacheFile, xsbti.compile.GlobalsCache _cache, xsbti.compile.IncOptions _incrementalCompilerOptions, xsbti.Reporter _reporter, java.util.Optional<xsbti.compile.CompileProgress> _progress, xsbti.T2<String, String>[] _extra) {
         super();
         perClasspathEntryLookup = _perClasspathEntryLookup;
@@ -56,9 +56,9 @@ public final class Setup implements java.io.Serializable {
         reporter = _reporter;
         progress = _progress;
         extra = _extra;
-        picklePromise = defaultPicklePromise();
+        irPromise = defaultIRPromise();
     }
-    protected Setup(xsbti.compile.PerClasspathEntryLookup _perClasspathEntryLookup, boolean _skip, java.io.File _cacheFile, xsbti.compile.GlobalsCache _cache, xsbti.compile.IncOptions _incrementalCompilerOptions, xsbti.Reporter _reporter, java.util.Optional<xsbti.compile.CompileProgress> _progress, xsbti.T2<String, String>[] _extra, java.util.concurrent.CompletableFuture<java.util.Optional<java.net.URI>> _picklePromise) {
+    protected Setup(xsbti.compile.PerClasspathEntryLookup _perClasspathEntryLookup, boolean _skip, java.io.File _cacheFile, xsbti.compile.GlobalsCache _cache, xsbti.compile.IncOptions _incrementalCompilerOptions, xsbti.Reporter _reporter, java.util.Optional<xsbti.compile.CompileProgress> _progress, xsbti.T2<String, String>[] _extra, java.util.concurrent.CompletableFuture<xsbti.compile.IR[]> _irPromise) {
         super();
         perClasspathEntryLookup = _perClasspathEntryLookup;
         skip = _skip;
@@ -68,7 +68,7 @@ public final class Setup implements java.io.Serializable {
         reporter = _reporter;
         progress = _progress;
         extra = _extra;
-        picklePromise = _picklePromise;
+        irPromise = _irPromise;
     }
     public xsbti.compile.PerClasspathEntryLookup perClasspathEntryLookup() {
         return this.perClasspathEntryLookup;
@@ -94,35 +94,35 @@ public final class Setup implements java.io.Serializable {
     public xsbti.T2<String, String>[] extra() {
         return this.extra;
     }
-    public java.util.concurrent.CompletableFuture<java.util.Optional<java.net.URI>> picklePromise() {
-        return this.picklePromise;
+    public java.util.concurrent.CompletableFuture<xsbti.compile.IR[]> irPromise() {
+        return this.irPromise;
     }
     public Setup withPerClasspathEntryLookup(xsbti.compile.PerClasspathEntryLookup perClasspathEntryLookup) {
-        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, picklePromise);
+        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, irPromise);
     }
     public Setup withSkip(boolean skip) {
-        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, picklePromise);
+        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, irPromise);
     }
     public Setup withCacheFile(java.io.File cacheFile) {
-        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, picklePromise);
+        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, irPromise);
     }
     public Setup withCache(xsbti.compile.GlobalsCache cache) {
-        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, picklePromise);
+        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, irPromise);
     }
     public Setup withIncrementalCompilerOptions(xsbti.compile.IncOptions incrementalCompilerOptions) {
-        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, picklePromise);
+        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, irPromise);
     }
     public Setup withReporter(xsbti.Reporter reporter) {
-        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, picklePromise);
+        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, irPromise);
     }
     public Setup withProgress(java.util.Optional<xsbti.compile.CompileProgress> progress) {
-        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, picklePromise);
+        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, irPromise);
     }
     public Setup withExtra(xsbti.T2<String, String>[] extra) {
-        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, picklePromise);
+        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, irPromise);
     }
-    public Setup withPicklePromise(java.util.concurrent.CompletableFuture<java.util.Optional<java.net.URI>> picklePromise) {
-        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, picklePromise);
+    public Setup withIrPromise(java.util.concurrent.CompletableFuture<xsbti.compile.IR[]> irPromise) {
+        return new Setup(perClasspathEntryLookup, skip, cacheFile, cache, incrementalCompilerOptions, reporter, progress, extra, irPromise);
     }
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -131,13 +131,13 @@ public final class Setup implements java.io.Serializable {
             return false;
         } else {
             Setup o = (Setup)obj;
-            return this.perClasspathEntryLookup().equals(o.perClasspathEntryLookup()) && (this.skip() == o.skip()) && this.cacheFile().equals(o.cacheFile()) && this.cache().equals(o.cache()) && this.incrementalCompilerOptions().equals(o.incrementalCompilerOptions()) && this.reporter().equals(o.reporter()) && this.progress().equals(o.progress()) && java.util.Arrays.deepEquals(this.extra(), o.extra()) && this.picklePromise().equals(o.picklePromise());
+            return this.perClasspathEntryLookup().equals(o.perClasspathEntryLookup()) && (this.skip() == o.skip()) && this.cacheFile().equals(o.cacheFile()) && this.cache().equals(o.cache()) && this.incrementalCompilerOptions().equals(o.incrementalCompilerOptions()) && this.reporter().equals(o.reporter()) && this.progress().equals(o.progress()) && java.util.Arrays.deepEquals(this.extra(), o.extra()) && this.irPromise().equals(o.irPromise());
         }
     }
     public int hashCode() {
-        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.Setup".hashCode()) + perClasspathEntryLookup().hashCode()) + (new Boolean(skip())).hashCode()) + cacheFile().hashCode()) + cache().hashCode()) + incrementalCompilerOptions().hashCode()) + reporter().hashCode()) + progress().hashCode()) + java.util.Arrays.deepHashCode(extra())) + picklePromise().hashCode());
+        return 37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "xsbti.compile.Setup".hashCode()) + perClasspathEntryLookup().hashCode()) + (new Boolean(skip())).hashCode()) + cacheFile().hashCode()) + cache().hashCode()) + incrementalCompilerOptions().hashCode()) + reporter().hashCode()) + progress().hashCode()) + java.util.Arrays.deepHashCode(extra())) + irPromise().hashCode());
     }
     public String toString() {
-        return "Setup("  + "perClasspathEntryLookup: " + perClasspathEntryLookup() + ", " + "skip: " + skip() + ", " + "cacheFile: " + cacheFile() + ", " + "cache: " + cache() + ", " + "incrementalCompilerOptions: " + incrementalCompilerOptions() + ", " + "reporter: " + reporter() + ", " + "progress: " + progress() + ", " + "extra: " + extra() + ", " + "picklePromise: " + picklePromise() + ")";
+        return "Setup("  + "perClasspathEntryLookup: " + perClasspathEntryLookup() + ", " + "skip: " + skip() + ", " + "cacheFile: " + cacheFile() + ", " + "cache: " + cache() + ", " + "incrementalCompilerOptions: " + incrementalCompilerOptions() + ", " + "reporter: " + reporter() + ", " + "progress: " + progress() + ", " + "extra: " + extra() + ", " + "irPromise: " + irPromise() + ")";
     }
 }

--- a/internal/compiler-interface/src/main/contraband/incremental.json
+++ b/internal/compiler-interface/src/main/contraband/incremental.json
@@ -321,17 +321,11 @@
           "since": "0.1.0"
         },
         {
-          "name": "picklepath",
-          "type": "java.net.URI*",
-          "default": "new java.net.URI[0]",
-          "doc": [
-            "Defines the picklepath to use for compilation.",
-            "A pickle path is the collection of URI handles that identify in-memory",
-            "Scala pickles. These pickles allow Zinc to pipeline compilation of",
-            "multi-module builds, allowing downstream modules to start compilation",
-            "after the phase pickler has been executed in all the dependent modules."
-          ],
-          "since": "1.2.0"
+          "name": "store",
+          "type": "xsbti.compile.IRStore",
+          "default": "xsbti.compile.EmptyIRStore.getStore()",
+          "doc": "Defines the IR store to use for compilation. Check the scaladoc of IR store.",
+          "since": "1.3.0"
         }
       ]
     },
@@ -476,22 +470,22 @@
         },
         { "name": "extra", "type": "xsbti.T2<String, String>*" },
         {
-          "name": "picklePromise",
-          "type": "java.util.concurrent.CompletableFuture<java.util.Optional<java.net.URI>>",
-          "default": "defaultPicklePromise()",
+          "name": "irPromise",
+          "type": "java.util.concurrent.CompletableFuture<xsbti.compile.IR[]>",
+          "default": "defaultIRPromise()",
           "doc": [
             "Allows the analysis callback to complete the future when",
             "the compiler is past the pickler gen phase, so that compilation",
             "clients can potentially start compilation of downstream projects."
           ],
-          "since": "1.2.0"
+          "since": "1.3.0"
         }
       ],
 
       "extra": [
-        "public static java.util.concurrent.CompletableFuture<java.util.Optional<java.net.URI>> defaultPicklePromise() {",
-        "    java.util.concurrent.CompletableFuture<java.util.Optional<java.net.URI>> p = new java.util.concurrent.CompletableFuture<java.util.Optional<java.net.URI>>();",
-        "    p.complete(java.util.Optional.empty());",
+        "public static java.util.concurrent.CompletableFuture<xsbti.compile.IR[]> defaultIRPromise() {",
+        "    java.util.concurrent.CompletableFuture<xsbti.compile.IR[]> p = new java.util.concurrent.CompletableFuture<xsbti.compile.IR[]>();",
+        "    p.complete(new xsbti.compile.IR[0]);",
         "    return p;",
         "}"
       ]

--- a/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
+++ b/internal/compiler-interface/src/main/java/xsbti/AnalysisCallback.java
@@ -8,9 +8,9 @@
 package xsbti;
 
 import xsbti.api.DependencyContext;
+import xsbti.compile.IR;
 
 import java.io.File;
-import java.net.URI;
 import java.util.EnumSet;
 
 public interface AnalysisCallback {
@@ -170,13 +170,9 @@ public interface AnalysisCallback {
     /**
      * Communicate to the callback that the API phase has finished.
      *
-     * For instance, you can use this method it to wait on asynchronous tasks.
-     *
-     * @param handle The URI that can be used to pass it in to downstream projects.
-     *               This URI serves as a unique identifier of the pickle files generated
-     *               in this compiler run, so every run generates a new URL.
+     * @param irs A sequence of IRs that can be used for build pipelining.
      */
-    void picklerPhaseCompleted(URI handle);
+    void irCompleted(IR[] irs);
 
     /**
      * Return whether incremental compilation is enabled or not.

--- a/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompiler.java
@@ -42,4 +42,16 @@ public interface CachedCompiler {
 	 * @param progress The compiler progress associated with a Scala compiler.
 	 */
 	void run(File[] sources, DependencyChanges changes, AnalysisCallback callback, Logger logger, Reporter delegate, CompileProgress progress);
+
+	/**
+	 * Run the cached Scala compiler with inputs of incremental compilation.
+	 *
+	 * @param sources The source files to be compiled.
+	 * @param changes The changes that have occurred since last compilation.
+	 * @param callback The callback injected by the incremental compiler.
+	 * @param logger The logger of the incremental compilation.
+	 * @param delegate The reporter that informs on the compiler's output.
+	 * @param progress The compiler progress associated with a Scala compiler.
+	 */
+	void run(File[] sources, DependencyChanges changes, AnalysisCallback callback, Logger logger, Reporter delegate, CompileProgress progress, IRStore store);
 }

--- a/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompilerProvider.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/CachedCompilerProvider.java
@@ -14,9 +14,9 @@ import xsbti.Reporter;
  * Represent a provider that creates cached Scala compilers from a Scala instance.
  */
 public interface CachedCompilerProvider {
-	/** Return the Scala instance used to provide cached compilers. */
-	ScalaInstance scalaInstance();
+    /** Return the Scala instance used to provide cached compilers. */
+    ScalaInstance scalaInstance();
 
-	/** Return a new cached compiler from the usual compiler input. */
-	CachedCompiler newCachedCompiler(String[] arguments, Output output, Logger log, Reporter reporter);
+    /** Return a new cached compiler from the usual compiler input. */
+    CachedCompiler newCachedCompiler(String[] arguments, Output output, Logger log, Reporter reporter);
 }

--- a/internal/compiler-interface/src/main/java/xsbti/compile/EmptyIRStore.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/EmptyIRStore.java
@@ -1,0 +1,20 @@
+package xsbti.compile;
+
+// Defined as an independent class because static methods in interfaces are not allowed <= JDK 8
+public class EmptyIRStore implements IRStore {
+    public EmptyIRStore() {}
+
+    public static EmptyIRStore getStore() {
+        return new EmptyIRStore();
+    }
+
+    @Override
+    public IR[] getDependentsIRs() {
+        return new IR[0];
+    }
+
+    @Override
+    public IRStore merge(IRStore other) {
+        return other;
+    }
+}

--- a/internal/compiler-interface/src/main/java/xsbti/compile/GlobalsCache.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/GlobalsCache.java
@@ -16,28 +16,28 @@ import xsbti.Reporter;
  */
 public interface GlobalsCache {
 
-	/**
-	 * Retrieve a {@link CachedCompiler}.
-	 *
-	 * @param args The arguments being passed on to the compiler.
-	 * @param output The output instance where the compiler stored class files.
-	 * @param forceNew Mark whether the previous cached compiler should be
-	 *                 thrown away and a new one should be returned.
-	 * @param provider The provider used for the cached compiler.
-	 * @param logger The logger used to log compiler output.
-	 * @param reporter The reporter used to report warnings and errors.
-	 *
-	 * @return An instance of the latest {@link CachedCompiler}.
-	 */
-	CachedCompiler apply(String[] args,
-	                     Output output,
-	                     boolean forceNew,
-	                     CachedCompilerProvider provider,
-	                     Logger logger,
-	                     Reporter reporter);
+    /**
+     * Retrieve a {@link CachedCompiler}.
+     *
+     * @param args The arguments being passed on to the compiler.
+     * @param output The output instance where the compiler stored class files.
+     * @param forceNew Mark whether the previous cached compiler should be
+     *                 thrown away and a new one should be returned.
+     * @param provider The provider used for the cached compiler.
+     * @param logger The logger used to log compiler output.
+     * @param reporter The reporter used to report warnings and errors.
+     *
+     * @return An instance of the latest {@link CachedCompiler}.
+     */
+    CachedCompiler apply(String[] args,
+                         Output output,
+                         boolean forceNew,
+                         CachedCompilerProvider provider,
+                         Logger logger,
+                         Reporter reporter);
 
-	/**
-	 * Clear the cache of {@link CachedCompiler cached compilers}.
-	 */
-	void clear();
+    /**
+     * Clear the cache of {@link CachedCompiler cached compilers}.
+     */
+    void clear();
 }

--- a/internal/compiler-interface/src/main/java/xsbti/compile/IR.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/IR.java
@@ -1,0 +1,59 @@
+package xsbti.compile;
+
+import java.io.File;
+
+/**
+ * Encodes a per-file compilation IR used by Scala 2 and Scala 3 compilers to
+ * provide build pipelining.
+ */
+public class IR {
+    private String name;
+    private File associatedOutput;
+    private byte[] content;
+
+    public IR(String name, File associatedOutput, byte[] content) {
+        this.name = name;
+        this.associatedOutput = associatedOutput;
+        this.content = content;
+    }
+
+    /**
+     * Returns a Zinc fully qualified name separated by `/` associated to the
+     * symbol that the given IR represents.
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns all the name components of `name`.
+     */
+    public String[] nameComponents() {
+        return name.split("/");
+    }
+
+    /**
+     * Returns the associated output to the IR. The output file can refer to
+     * either a JAR or a classes directory. In the presence of multiple classes
+     * directory, only the one associated to the symbol that created this IR
+     * is used.
+     *
+     * This information is required by the incremental compiler to know where a
+     * given IR comes from. It's thus critical to correctly register dependencies
+     * (check `processDependency` in the `Dependency` incremental phase in the
+     * Scala 2 bridge for more information).
+     *
+     * @return The output file associated with it.
+     */
+    public File associatedOutput() {
+        return associatedOutput;
+    }
+
+    /**
+     * Returns a generic representation of a compilation IR (be it Scala 2 pickles
+     * or Scala 3 Tasty trees).
+     */
+    public byte[] content() {
+        return content;
+    }
+}

--- a/internal/compiler-interface/src/main/java/xsbti/compile/IRStore.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/IRStore.java
@@ -1,0 +1,30 @@
+package xsbti.compile;
+
+/**
+ * A store used by the compiler bridge to populate the symbol table from the IRs
+ * collected in it instead of class files. It also allows the compiler bridge to
+ * store the IR associated with a given project.
+ */
+public interface IRStore {
+   /**
+    * Returns all IRs in this store. This method is usually called in the bridge
+    * to obtain all the IRs of the dependent modules of a project to populate the
+    * symbol table.
+    */
+   IR[] getDependentsIRs();
+
+   /**
+    * Merges two store instances and its corresponding IRs.
+    *
+    * If there are IR instances associated with the same output that clash with
+    * the same name, the IRs of the `other` store take precedence over the ones
+    * in the first store.
+    *
+    * This operation is used to merge the products of incremental compiler runs
+    * in the context of build pipelining.
+    *
+    * @param other The store we want to merge with the current one.
+    * @return A store containing the IR instances of both stores.
+    */
+   IRStore merge(IRStore other);
+}

--- a/internal/compiler-interface/src/main/java/xsbti/compile/IncrementalCompiler.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/IncrementalCompiler.java
@@ -12,7 +12,6 @@ import xsbti.Reporter;
 import xsbti.T2;
 
 import java.io.File;
-import java.net.URI;
 import java.util.Optional;
 
 /*

--- a/internal/compiler-interface/src/main/java/xsbti/compile/ScalaCompiler.java
+++ b/internal/compiler-interface/src/main/java/xsbti/compile/ScalaCompiler.java
@@ -18,58 +18,120 @@ import java.util.Optional;
  * Represent the interface of a Scala compiler.
  */
 public interface ScalaCompiler {
-	/**
-	 * Return the {@link ScalaInstance} used by this instance of the compiler.
-	 */
-	ScalaInstance scalaInstance();
+    /**
+     * Return the {@link ScalaInstance} used by this instance of the compiler.
+     */
+    ScalaInstance scalaInstance();
 
-	/**
-	 * Recompile the subset of <code>sources</code> impacted by the
-	 * changes defined in <code>changes</code> and collect the new APIs.
-	 *
-	 * @param sources  All the sources of the project.
-	 * @param changes  The changes that have been detected at the previous step.
-	 * @param callback The callback to which the extracted information should be
-	 *                 reported.
-	 * @param log      The logger in which the Scala compiler will log info.
-	 * @param reporter The reporter to which errors and warnings should be
-	 *                 reported during compilation.
-	 * @param progress Where to report the file being currently compiled.
-	 * @param compiler The actual compiler that will perform the compilation step.
-	 */
-	void compile(File[] sources,
-	             DependencyChanges changes,
-	             AnalysisCallback callback,
-	             Logger log,
-	             Reporter reporter,
-	             CompileProgress progress,
-	             CachedCompiler compiler);
+    /**
+     * Recompile the subset of <code>sources</code> impacted by the
+     * changes defined in <code>changes</code> and collect the new APIs.
+     *
+     * @param sources  All the sources of the project.
+     * @param changes  The changes that have been detected at the previous step.
+     * @param callback The callback to which the extracted information should be
+     *                 reported.
+     * @param log      The logger in which the Scala compiler will log info.
+     * @param reporter The reporter to which errors and warnings should be
+     *                 reported during compilation.
+     * @param progress Where to report the file being currently compiled.
+     * @param compiler The actual compiler that will perform the compilation step.
+     *
+     * @deprecated Use {@link #compile(File[], DependencyChanges, String[], Output, AnalysisCallback, Reporter, GlobalsCache, Logger, Optional, IRStore)} instead,
+     * which specifies the IR store to be used for compilation.
+     */
+    @Deprecated
+    void compile(File[] sources,
+                 DependencyChanges changes,
+                 AnalysisCallback callback,
+                 Logger log,
+                 Reporter reporter,
+                 CompileProgress progress,
+                 CachedCompiler compiler);
 
-	/**
-	 * Recompile the subset of <code>sources</code> impacted by the
-	 * changes defined in <code>changes</code> and collect the new APIs.
-	 *
-	 * @param sources     All the sources of the project.
-	 * @param changes     The changes that have been detected at the previous step.
-	 * @param options     The arguments to give to the Scala compiler.
-	 *                    For more information, run `scalac -help`.
-	 * @param output      The location where generated class files should be put.
-	 * @param callback    The callback to which the extracted information should
-	 *                    be reported.
-	 * @param reporter    The reporter to which errors and warnings should be
-	 *                    reported during compilation.
-	 * @param cache       The cache from where we retrieve the compiler to use.
-	 * @param log         The logger in which the Scala compiler will log info.
-	 * @param progressOpt The progress interface in which the Scala compiler
-	 *                    will report on the file being compiled.
-	 */
-	void compile(File[] sources,
-	             DependencyChanges changes,
-	             String[] options,
-	             Output output,
-	             AnalysisCallback callback,
-	             Reporter reporter,
-	             GlobalsCache cache,
-	             Logger log,
-	             Optional<CompileProgress> progressOpt);
+    /**
+     * Recompile the subset of <code>sources</code> impacted by the
+     * changes defined in <code>changes</code> and collect the new APIs.
+     *
+     * @param sources  All the sources of the project.
+     * @param changes  The changes that have been detected at the previous step.
+     * @param callback The callback to which the extracted information should be
+     *                 reported.
+     * @param log      The logger in which the Scala compiler will log info.
+     * @param reporter The reporter to which errors and warnings should be
+     *                 reported during compilation.
+     * @param progress Where to report the file being currently compiled.
+     * @param compiler The actual compiler that will perform the compilation step.
+     */
+    void compile(File[] sources,
+                 DependencyChanges changes,
+                 AnalysisCallback callback,
+                 Logger log,
+                 Reporter reporter,
+                 CompileProgress progress,
+                 IRStore store,
+                 CachedCompiler compiler);
+
+    /**
+     * Recompile the subset of <code>sources</code> impacted by the
+     * changes defined in <code>changes</code> and collect the new APIs.
+     *
+     * @param sources     All the sources of the project.
+     * @param changes     The changes that have been detected at the previous step.
+     * @param options     The arguments to give to the Scala compiler.
+     *                    For more information, run `scalac -help`.
+     * @param output      The location where generated class files should be put.
+     * @param callback    The callback to which the extracted information should
+     *                    be reported.
+     * @param reporter    The reporter to which errors and warnings should be
+     *                    reported during compilation.
+     * @param cache       The cache from where we retrieve the compiler to use.
+     * @param log         The logger in which the Scala compiler will log info.
+     * @param progressOpt The progress interface in which the Scala compiler
+     *                    will report on the file being compiled.
+     *
+     * @deprecated Use {@link #compile(File[], DependencyChanges, String[], Output, AnalysisCallback, Reporter, GlobalsCache, Logger, Optional, IRStore)} instead,
+     * which specifies the IR store to be used for compilation.
+     */
+    @Deprecated
+    void compile(File[] sources,
+                 DependencyChanges changes,
+                 String[] options,
+                 Output output,
+                 AnalysisCallback callback,
+                 Reporter reporter,
+                 GlobalsCache cache,
+                 Logger log,
+                 Optional<CompileProgress> progressOpt);
+
+    /**
+     * Recompile the subset of <code>sources</code> impacted by the
+     * changes defined in <code>changes</code> and collect the new APIs.
+     *
+     * @param sources     All the sources of the project.
+     * @param changes     The changes that have been detected at the previous step.
+     * @param options     The arguments to give to the Scala compiler.
+     *                    For more information, run `scalac -help`.
+     * @param output      The location where generated class files should be put.
+     * @param callback    The callback to which the extracted information should
+     *                    be reported.
+     * @param reporter    The reporter to which errors and warnings should be
+     *                    reported during compilation.
+     * @param cache       The cache from where we retrieve the compiler to use.
+     * @param log         The logger in which the Scala compiler will log info.
+     * @param progressOpt The progress interface in which the Scala compiler
+     *                    will report on the file being compiled.
+     * @param store       The store that contains the IR files to populate the symbol table
+     *                    under build pipelining.
+     */
+    void compile(File[] sources,
+                 DependencyChanges changes,
+                 String[] options,
+                 Output output,
+                 AnalysisCallback callback,
+                 Reporter reporter,
+                 GlobalsCache cache,
+                 Logger log,
+                 Optional<CompileProgress> progressOpt,
+                 IRStore store);
 }

--- a/internal/compiler-interface/src/test/scala/xsbti/TestCallback.scala
+++ b/internal/compiler-interface/src/test/scala/xsbti/TestCallback.scala
@@ -6,6 +6,7 @@ import java.util
 import java.util.Optional
 
 import xsbti.api.{ ClassLike, DependencyContext }
+import xsbti.compile.IR
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -78,7 +79,7 @@ class TestCallback extends AnalysisCallback {
 
   override def dependencyPhaseCompleted(): Unit = {}
   override def apiPhaseCompleted(): Unit = {}
-  override def picklerPhaseCompleted(handle: URI): Unit = {}
+  override def irCompleted(irs: Array[IR]): Unit = {}
 }
 
 object TestCallback {

--- a/internal/zinc-benchmarks/src/main/scala/xsbt/ZincBenchmark.scala
+++ b/internal/zinc-benchmarks/src/main/scala/xsbt/ZincBenchmark.scala
@@ -14,7 +14,7 @@ import sbt.internal.util.ConsoleLogger
 import sbt.io.{ IO, RichFile }
 import xsbt.ZincBenchmark.CompilationInfo
 import xsbti._
-import xsbti.compile.SingleOutput
+import xsbti.compile.{ EmptyIRStore, SingleOutput }
 
 import scala.util.Try
 
@@ -142,6 +142,7 @@ private[xsbt] object ZincBenchmark {
     val delegatingReporter = DelegatingReporter(settings, ConsoleReporter)
     val compiler: ZincCompiler = cachedCompiler.compiler
     compiler.set(analysisCallback, delegatingReporter)
+    compiler.setUpIRStore(EmptyIRStore.getStore)
     compiler
   }
 

--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerCache.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/CompilerCache.scala
@@ -12,11 +12,12 @@ package inc
 import java.util
 
 import xsbti.{ Reporter, Logger => xLogger }
-import xsbti.compile.{ CachedCompiler, CachedCompilerProvider, GlobalsCache, Output }
+import xsbti.compile.{ CachedCompiler, CachedCompilerProvider, GlobalsCache, IRStore, Output }
 import sbt.util.InterfaceUtil.{ toSupplier => f0 }
 
 /**
  * Manage a number of <code>maxInstance</code> of cached Scala compilers.
+ *
  * @param maxInstances The maximum number to be cached.
  */
 final class CompilerCache(val maxInstances: Int) extends GlobalsCache {

--- a/zinc/src/main/scala/sbt/internal/inc/CompileConfiguration.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/CompileConfiguration.scala
@@ -18,6 +18,7 @@ import xsbti.compile.{
   CompileAnalysis,
   CompileProgress,
   GlobalsCache,
+  IRStore,
   IncOptions,
   MiniSetup,
   PerClasspathEntryLookup
@@ -29,6 +30,7 @@ import xsbti.compile.{
  * @param sources
  * @param classpath
  * @param classpathOptions
+ * @param store
  * @param previousAnalysis
  * @param previousSetup
  * @param currentSetup
@@ -44,7 +46,7 @@ final class CompileConfiguration(
     val sources: Seq[File],
     val classpath: Seq[File],
     val classpathOptions: ClasspathOptions,
-    val picklepath: Seq[URI],
+    val store: IRStore,
     val previousAnalysis: CompileAnalysis,
     val previousSetup: Option[MiniSetup],
     val currentSetup: MiniSetup,

--- a/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
+++ b/zinc/src/main/scala/sbt/internal/inc/MixedAnalyzingCompiler.scala
@@ -72,36 +72,18 @@ final class MixedAnalyzingCompiler(
         val arguments =
           cArgs(classpathOptions)(Nil, absClasspath, None, options.scalacOptions)
         timed("Scala compilation", log) {
-          // Set up the pickle path if the underlyin compiler is our analyzing compiler
-          compiler match {
-            case a: AnalyzingCompiler =>
-              a.compileAndSetUpPicklepath(
-                sources.toArray,
-                picklepath.toArray,
-                changes,
-                arguments.toArray,
-                output,
-                callback,
-                reporter,
-                config.cache,
-                log,
-                progress.toOptional
-              )
-            case _ =>
-              if (picklepath.nonEmpty)
-                log.warn(s"Ignoring pickle path because underlying compiler doesn't support it.")
-              compiler.compile(
-                sources.toArray,
-                changes,
-                arguments.toArray,
-                output,
-                callback,
-                reporter,
-                config.cache,
-                log,
-                progress.toOptional
-              )
-          }
+          compiler.compile(
+            sources.toArray,
+            changes,
+            arguments.toArray,
+            output,
+            callback,
+            reporter,
+            config.cache,
+            log,
+            progress.toOptional,
+            config.store
+          )
         }
       }
 
@@ -189,7 +171,7 @@ object MixedAnalyzingCompiler {
       javac: xsbti.compile.JavaCompiler,
       sources: Seq[File],
       classpath: Seq[File],
-      picklepath: Seq[URI],
+      store: IRStore,
       output: Output,
       cache: GlobalsCache,
       progress: Option[CompileProgress] = None,
@@ -232,7 +214,7 @@ object MixedAnalyzingCompiler {
       sources,
       classpath,
       classpathOptions,
-      picklepath,
+      store,
       compileSetup,
       progress,
       previousAnalysis,
@@ -251,7 +233,7 @@ object MixedAnalyzingCompiler {
       sources: Seq[File],
       classpath: Seq[File],
       classpathOptions: ClasspathOptions,
-      picklepath: Seq[URI],
+      store: IRStore,
       setup: MiniSetup,
       progress: Option[CompileProgress],
       previousAnalysis: CompileAnalysis,
@@ -268,7 +250,7 @@ object MixedAnalyzingCompiler {
       sources,
       classpath,
       classpathOptions,
-      picklepath,
+      store,
       previousAnalysis,
       previousSetup,
       setup,
@@ -360,7 +342,7 @@ object MixedAnalyzingCompiler {
   }
 
   /**
-   * Create a an analysis store cache at the desired location.
+   * Create a an analysis put cache at the desired location.
    *
    * Note: This method will be deprecated after Zinc 1.1.
    */

--- a/zinc/src/test/scala/sbt/inc/cached/CachedHashingSpec.scala
+++ b/zinc/src/test/scala/sbt/inc/cached/CachedHashingSpec.scala
@@ -9,9 +9,11 @@ package sbt.inc.cached
 
 import java.nio.file.{ Path, Paths }
 import java.io.File
+
 import sbt.inc.{ BaseCompilerSpec, SourceFiles }
 import sbt.internal.inc.{ Analysis, CompileOutput, MixedAnalyzingCompiler }
 import sbt.io.IO
+import xsbti.compile.{ EmptyIRStore }
 
 class CachedHashingSpec extends BaseCompilerSpec {
   def timeMs[R](block: => R): Long = {
@@ -41,7 +43,7 @@ class CachedHashingSpec extends BaseCompilerSpec {
         javac,
         options.sources,
         giganticClasspath,
-        Nil,
+        EmptyIRStore.getStore(),
         CompileOutput(options.classesDirectory),
         setup.cache,
         setup.progress.toOption,
@@ -85,7 +87,7 @@ class CachedHashingSpec extends BaseCompilerSpec {
         javac,
         options.sources,
         List(fakeLibraryJar),
-        Nil,
+        EmptyIRStore.getStore,
         CompileOutput(options.classesDirectory),
         setup.cache,
         setup.progress.toOption,


### PR DESCRIPTION
Adds `IRStore` and `IR` to the compiler APIs and replaces the clumsy use
of `List[URI]` in the analysis callback and the external API that was
used to propagate IDs to handles in the core of the compiler bridge.

This change has the benefit of pushing the management of the IRs
lifetime to the implementor of `IRStore` and avoiding altogether the
cleanup of the previously compiler-level map that contained all the IRs
created by the compiler runs.