### PR TITLE
Change ZincSymbolLoaders to work with Hydra zinc overlays

### DIFF
--- a/internal/compiler-bridge/src/main/scala-2.11/xsbt/ZincSymbolLoaders.scala
+++ b/internal/compiler-bridge/src/main/scala-2.11/xsbt/ZincSymbolLoaders.scala
@@ -4,7 +4,7 @@ import Compat._
 import java.io.File
 import scala.collection.mutable
 
-abstract class ZincSymbolLoaders extends GlobalSymbolLoaders with ZincPickleCompletion {
+trait ZincSymbolLoaders extends GlobalSymbolLoaders with ZincPickleCompletion {
   import global._
   import scala.tools.nsc.io.AbstractFile
   import scala.tools.nsc.util.ClassRepresentation

--- a/internal/compiler-bridge/src/main/scala-2.12/xsbt/ZincSymbolLoaders.scala
+++ b/internal/compiler-bridge/src/main/scala-2.12/xsbt/ZincSymbolLoaders.scala
@@ -5,7 +5,7 @@ import java.io.File
 import scala.collection.mutable
 import scala.tools.nsc.ZincPicklePath
 
-abstract class ZincSymbolLoaders extends GlobalSymbolLoaders with ZincPickleCompletion {
+trait ZincSymbolLoaders extends GlobalSymbolLoaders with ZincPickleCompletion {
   import global._
   import scala.tools.nsc.io.AbstractFile
   import scala.tools.nsc.util.ClassRepresentation

--- a/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/CallbackGlobal.scala
@@ -26,13 +26,9 @@ sealed abstract class CallbackGlobal(
     reporter: reporters.Reporter,
     output: Output
 ) extends Global(settings, reporter)
+    with ExtraGlobal
     with ZincPicklePath {
   import Compat._
-
-  override lazy val loaders = new {
-    val global: CallbackGlobal.this.type = CallbackGlobal.this
-    val platform: CallbackGlobal.this.platform.type = CallbackGlobal.this.platform
-  } with ZincSymbolLoaders
 
   def setInvalidatedClassFiles(invalidatedClassFiles: Array[File]): Unit = {
     loaders.invalidatedClassFilePaths.clear()

--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtraGlobal.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtraGlobal.scala
@@ -1,0 +1,15 @@
+package xsbt
+
+/*
+ * Marker trait used to facilitate integration of Triplequote Hydra with Bloop.
+ *
+ * Note: The bloop-hydra-bridge source component provides an alternative implementation
+ * of this trait so if you need to modify this file please get in touch with
+ * [[https://github.com/dotta/ Mirco Dotta]] or [[https://github.com/dragos/ Iulian Dragos]].
+ */
+trait ExtraGlobal { self: CallbackGlobal =>
+  override lazy val loaders = new {
+    val global: self.type = self
+    val platform: self.platform.type = self.platform
+  } with ZincSymbolLoaders
+}

--- a/internal/compiler-bridge/src/main/scala_2.10/xsbt/ZincSymbolLoaders.scala
+++ b/internal/compiler-bridge/src/main/scala_2.10/xsbt/ZincSymbolLoaders.scala
@@ -4,7 +4,7 @@ import Compat._
 import java.io.File
 import scala.collection.mutable
 
-abstract class ZincSymbolLoaders extends GlobalSymbolLoaders {
+trait ZincSymbolLoaders extends GlobalSymbolLoaders {
   val invalidatedClassFilePaths: mutable.HashSet[String] = new mutable.HashSet[String]()
 
   import global._

--- a/internal/compiler-bridge/src/main/scala_2.11-12/xsbt/ZincPickleCompletion.scala
+++ b/internal/compiler-bridge/src/main/scala_2.11-12/xsbt/ZincPickleCompletion.scala
@@ -1,10 +1,11 @@
 package xsbt
 
 import scala.reflect.io.NoAbstractFile
+import scala.tools.nsc.Global
 import scala.tools.nsc.io.AbstractFile
 
 trait ZincPickleCompletion {
-  val global: CallbackGlobal
+  val global: Global
   import global._
 
   /** Load source or class file for `root` from Scala pickles.

--- a/internal/compiler-bridge/src/main/scala_2.13/xsbt/ZincPickleCompletion.scala
+++ b/internal/compiler-bridge/src/main/scala_2.13/xsbt/ZincPickleCompletion.scala
@@ -1,10 +1,11 @@
 package xsbt
 
 import scala.reflect.io.NoAbstractFile
+import scala.tools.nsc.Global
 import scala.tools.nsc.io.AbstractFile
 
 trait ZincPickleCompletion {
-  val global: CallbackGlobal
+  val global: Global
   import global._
 
   /** Load source or class file for `root` from Scala pickles.

--- a/internal/compiler-bridge/src/main/scala_2.13/xsbt/ZincSymbolLoaders.scala
+++ b/internal/compiler-bridge/src/main/scala_2.13/xsbt/ZincSymbolLoaders.scala
@@ -4,7 +4,7 @@ import Compat._
 import java.io.File
 import scala.collection.mutable
 
-abstract class ZincSymbolLoaders extends GlobalSymbolLoaders with ZincPickleCompletion {
+trait ZincSymbolLoaders extends GlobalSymbolLoaders with ZincPickleCompletion {
   import global._
   import scala.tools.nsc.io.AbstractFile
   import scala.tools.nsc.util.ClassRepresentation


### PR DESCRIPTION
Changes required on zinc to allow integration of Hydra with Bloop.

I'm targeting the `topic/bloop-rebase` branch as that seems the branch Bloop is linking against, but please let me know if I got that wrong and I'll rebase my changes.

I'm planning to also contribute an integration test, but I need this PR to be merged first as the bloop-hydra-bridge (the sources component allowing integration of Hydra with Bloop) requires the changes in this PR to successfully compile. And, because the integration test would require the bloop-hydra-bridge to be published, I need to break the cycle. Hence the reason for delaying testing in a followup PR.

\cc @dragos