### PR TITLE
Support all schemes in DiagnosticsReporter

### DIFF
--- a/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
+++ b/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala
@@ -104,7 +104,13 @@ object DiagnosticsReporter {
         }
 
       val source: Option[JavaFileObject] = Option(d.getSource)
-      val sourcePath: Option[String] = source map (obj => IO.toFile(obj.toUri).getAbsolutePath)
+      val sourcePath: Option[String] = source match {
+        case Some(obj) =>
+          val uri = obj.toUri
+          if (uri.getScheme == "file") Some(IO.toFile(uri).getAbsolutePath)
+          else Some(uri.toString)
+        case _ => None
+      }
       val line: Optional[Integer] = o2jo(checkNoPos(d.getLineNumber) map (_.toInt))
       val offset: Optional[Integer] = o2jo(checkNoPos(d.getPosition) map (_.toInt))
       val startOffset: Optional[Integer] = o2jo(checkNoPos(d.getStartPosition) map (_.toInt))


### PR DESCRIPTION
Previously, `DiagnosticsReporter` would crash when a message was
reported with a URI using a scheme different than `file`, because we
would fail at getting an absolute path.

Now, if the scheme is not `file`, we simply report the string
representation of the URI as position of the error.

This error is triggered, for instance, when an annotation whose
classfile cannot be found is encountered in a JAR.

See scalacenter/bloop#1296